### PR TITLE
Fix ValueError: Unicode strings with encoding declaration are not sup…

### DIFF
--- a/image_scraper/utils.py
+++ b/image_scraper/utils.py
@@ -126,7 +126,7 @@ class ImageScraper(object):
             except requests.exceptions.ConnectionError:
                 raise PageLoadError(None)
             try:
-                page_html = page.text
+                page_html = page.content
                 page_url = page.url
             except UnboundLocalError:
                 raise PageLoadError(None)


### PR DESCRIPTION
…ported.

When try to download from Chinese or Japanese website, got this error:

ImageScraper
============
Requesting page....

Traceback (most recent call last):
  File "/root/ImageScraper/bin/image-scraper", line 11, in <module>
    sys.exit(console_main())
  File "/root/ImageScraper/lib/python3.5/site-packages/image_scraper/mains.py", line 28, in console_main
    scraper.get_img_list()
  File "/root/ImageScraper/lib/python3.5/site-packages/image_scraper/utils.py", line 123, in get_img_list
    tree = html.fromstring(self.page_html)
  File "/root/ImageScraper/lib/python3.5/site-packages/lxml/html/__init__.py", line 876, in fromstring
    doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
  File "/root/ImageScraper/lib/python3.5/site-packages/lxml/html/__init__.py", line 762, in document_fromstring
    value = etree.fromstring(html, parser, **kw)
  File "src/lxml/etree.pyx", line 3230, in lxml.etree.fromstring (src/lxml/etree.c:81070)
  File "src/lxml/parser.pxi", line 1866, in lxml.etree._parseMemoryDocument (src/lxml/etree.c:121191)
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.

Switch to .content which returns bytes instead of .text which returns unicode.